### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,13 @@
 language: ruby
 
 rvm:
-  - 2.0.*
   - 2.1.*
   - 2.2.*
-  - 2.3.0
+  - 2.3.5
+  - 2.4.2
 
 gemfile:
   - Gemfile
-  - Gemfile.fluentd.0.12
-
-matrix:
-  exclude:
-    - rvm: 2.0.*
-      gemfile: Gemfile
 
 before_install: gem update bundler
 

--- a/Gemfile.fluentd.0.12
+++ b/Gemfile.fluentd.0.12
@@ -1,8 +1,0 @@
-source 'https://rubygems.org'
-
-gem 'fluentd', '~> 0.12.0'
-gemspec
-
-group :development do
-  gem 'kramdown'
-end

--- a/fluent-plugin-exec_placeholder.gemspec
+++ b/fluent-plugin-exec_placeholder.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'fluentd'
+  gem.add_dependency 'fluentd', ['>= 0.14.0', '< 2']
 
   gem.add_development_dependency 'test-unit'
   gem.add_development_dependency 'bundler'

--- a/lib/fluent/plugin/out_exec_placeholder.rb
+++ b/lib/fluent/plugin/out_exec_placeholder.rb
@@ -1,6 +1,7 @@
 require 'erb'
+require 'fluent/plugin/output'
 
-module Fluent
+module Fluent::Plugin
   class ExecPlaceholderOutput < Output
     Fluent::Plugin.register_output('exec_placeholder', self)
     PLACEHOLDER_REGEXP = /\$\{([^}]+)\}/
@@ -26,7 +27,7 @@ module Fluent
       [tag, time, record].to_msgpack
     end
 
-    def emit(tag, es, chain)
+    def process(tag, es)
       es.each {|time, record|
         prog = get_prog(tag, time, record)
         system(prog)
@@ -35,7 +36,6 @@ module Fluent
           raise "command returns #{ecode}: #{prog}"
         end
       }
-      chain.next
     end
 
     private

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,7 +12,10 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'fluent/test'
+require 'fluent/test/helpers'
+require 'fluent/test/driver/output'
 require 'fluent/plugin/out_exec_placeholder'
 
 class Test::Unit::TestCase
+  include Fluent::Test::Helpers
 end

--- a/test/plugin/test_out_exec_placeholder.rb
+++ b/test/plugin/test_out_exec_placeholder.rb
@@ -1,11 +1,12 @@
 require 'helper'
 class ExecPlaceholderOutputTest < Test::Unit::TestCase
+
   def setup
     Fluent::Test.setup
   end
 
-  def create_driver(conf = CONFIG, tag='test')
-    Fluent::Test::OutputTestDriver.new(Fluent::ExecPlaceholderOutput, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::ExecPlaceholderOutput).configure(conf)
   end
 
   def test_configure
@@ -18,12 +19,10 @@ class ExecPlaceholderOutputTest < Test::Unit::TestCase
   def test_emit
     d1 = create_driver(%[
       command echo ${tag}
-      ],
-      'input.access'
-    )
-    d1.run do
-      d1.emit({'domain' => 'www.google.com', 'path' => '/foo/bar?key=value', 'agent' => 'Googlebot', 'response_time' => 1000000})
-      d1.emit({'domain' => 'news.google.com', 'path' => '/', 'agent' => 'Googlebot-Mobile', 'response_time' => 900000})
+    ])
+    d1.run(default_tag: 'input.access') do
+      d1.feed({'domain' => 'www.google.com', 'path' => '/foo/bar?key=value', 'agent' => 'Googlebot', 'response_time' => 1000000})
+      d1.feed({'domain' => 'news.google.com', 'path' => '/', 'agent' => 'Googlebot-Mobile', 'response_time' => 900000})
     end
   end
 end


### PR DESCRIPTION
I've tried to migrate to use v0.14 Output Plugin API.
This PR contains major update change and also includes in breaking changes.
If above questions/problems are acceptable or reasonable for you, could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks.